### PR TITLE
firamedium set for page number

### DIFF
--- a/programming.cls
+++ b/programming.cls
@@ -774,7 +774,7 @@
 \setkomafont{pagenumber}{\firamedium}
 \cfoot{%
   \ifdefvoid\P@ArticleNumber{}{%
-    \usekomafont{pagenumber}\mdseries\P@ArticleNumber\P@pagemarkseparator}%
+    \usekomafont{pagenumber}\mdseries\firamedium\P@ArticleNumber\P@pagemarkseparator}%
   \pagemark}
 
 


### PR DESCRIPTION
Page numbers comprise the article number and the page number, with a page mark separator in between.  However, the two numbers appear in different fonts.  This fix forces \firamedium on the article number to match the font of the page number.