### PR TITLE
Replace use of the deprecated '\ifstr' cmd by `\Ifstr'

### DIFF
--- a/programming.cls
+++ b/programming.cls
@@ -107,8 +107,8 @@
 
 \newbool{P@submission}
 \P@Key{phase}[final]{%
-  \ifstr{#1}{final}{\boolfalse{P@submission}}{}
-  \ifstr{#1}{submission}{\booltrue{P@submission}}{}
+  \Ifstr{#1}{final}{\boolfalse{P@submission}}{}
+  \Ifstr{#1}{submission}{\booltrue{P@submission}}{}
   \FamilyKeyStateProcessed}
 \P@StdOption{submission}{phase=submission}
 \P@StdOption{crc}{phase=final}


### PR DESCRIPTION
This PR solve the open [issue #30](https://github.com/programming-journal/programming/issues/30) by @krono