### PR TITLE
Add a GitHub Actions setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,28 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Compile LaTeX document (PdfLaTeX)
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/texlive-action/full@v1
         with:
-          root_file: example-programming.tex
+          run: |
+             pdflatex example-programming
+             biber    example-programming
+             pdflatex example-programming
+             pdflatex example-programming
 
       - name: Compile LaTeX document (XeLaTeX)
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/texlive-action/full@v1
         with:
-          root_file: example-programming.tex
-          latexmk_use_xelatex: true
+          run: |
+             xelatex example-programming
+             biber   example-programming
+             xelatex example-programming
+             xelatex example-programming
 
       - name: Compile LaTeX document (LuaLaTeX)
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/texlive-action/full@v1
         with:
-          root_file: example-programming.tex
-          latexmk_use_lualatex: true
+          run: |
+             lualatex example-programming
+             biber    example-programming
+             lualatex example-programming
+             lualatex example-programming

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Latex
-        run: sudo apt-get install texlive-base texlive-fonts-extra texlive-luatex biber texlive-xetex texlive-latex-extra texlive-lang-greek texlive-lang-cyrillic
+        run: sudo apt-get install texlive-base texlive-fonts-extra texlive-luatex biber texlive-xetex texlive-latex-extra texlive-lang-greek texlive-lang-cyrillic texlive-science
 
       - name: Set up Git repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+
+      - name: Compile LaTeX document (PdfLaTeX)
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: example-programming.tex
+
+      - name: Compile LaTeX document (XeLaTeX)
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: example-programming.tex
+          latexmk_use_xelatex: true
+
+      - name: Compile LaTeX document (LuaLaTeX)
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: example-programming.tex
+          latexmk_use_lualatex: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
            pdflatex example-programming
            pdflatex example-programming
 
-      - name: Compile LaTeX document (XeLaTeX)
-        run: |
-           xelatex example-programming
-           biber   example-programming
-           xelatex example-programming
-           xelatex example-programming
-
       - name: Compile LaTeX document (LuaLaTeX)
         run: |
            lualatex example-programming
            biber    example-programming
            lualatex example-programming
            lualatex example-programming
+
+      - name: Compile LaTeX document (XeLaTeX)
+        run: |
+           xelatex example-programming
+           biber   example-programming
+           xelatex example-programming
+           xelatex example-programming

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,34 +4,31 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
+      - name: Setup Latex
+        run: sudo apt-get install texlive-base texlive-fonts-extra texlive-luatex biber texlive-xetex texlive-latex-extra texlive-lang-greek texlive-lang-cyrillic
+
       - name: Set up Git repository
         uses: actions/checkout@v2
 
       - name: Compile LaTeX document (PdfLaTeX)
-        uses: xu-cheng/texlive-action/full@v1
-        with:
-          run: |
-             pdflatex example-programming
-             biber    example-programming
-             pdflatex example-programming
-             pdflatex example-programming
+        run: |
+           pdflatex example-programming
+           biber    example-programming
+           pdflatex example-programming
+           pdflatex example-programming
 
       - name: Compile LaTeX document (XeLaTeX)
-        uses: xu-cheng/texlive-action/full@v1
-        with:
-          run: |
-             xelatex example-programming
-             biber   example-programming
-             xelatex example-programming
-             xelatex example-programming
+        run: |
+           xelatex example-programming
+           biber   example-programming
+           xelatex example-programming
+           xelatex example-programming
 
       - name: Compile LaTeX document (LuaLaTeX)
-        uses: xu-cheng/texlive-action/full@v1
-        with:
-          run: |
-             lualatex example-programming
-             biber    example-programming
-             lualatex example-programming
-             lualatex example-programming
+        run: |
+           lualatex example-programming
+           biber    example-programming
+           lualatex example-programming
+           lualatex example-programming

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,31 +4,25 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Setup Latex
-        run: sudo apt-get install texlive-base texlive-fonts-extra texlive-luatex biber texlive-xetex texlive-latex-extra texlive-lang-greek texlive-lang-cyrillic texlive-science
-
       - name: Set up Git repository
         uses: actions/checkout@v2
 
       - name: Compile LaTeX document (PdfLaTeX)
-        run: |
-           pdflatex example-programming
-           biber    example-programming
-           pdflatex example-programming
-           pdflatex example-programming
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file: example-programming.tex
+          compiler: pdflatex
 
       - name: Compile LaTeX document (LuaLaTeX)
-        run: |
-           lualatex example-programming
-           biber    example-programming
-           lualatex example-programming
-           lualatex example-programming
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file: example-programming.tex
+          compiler: lualatex
 
       - name: Compile LaTeX document (XeLaTeX)
-        run: |
-           xelatex example-programming
-           biber   example-programming
-           xelatex example-programming
-           xelatex example-programming
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file: example-programming.tex
+          compiler: xelatex


### PR DESCRIPTION
I was perhaps a little too optimistic, though, it turns out it's really hard to make the example compile.

The simplest setups are in the first two commits.

Unfortunately, there's an issue with the `tabularx` package, which doesn't like the tabular in the example.

Trying a Ubuntu 18.04 setup fails because we need a newer hyperxmp.

Ubuntu 20.04 fixes that issue.

Though, now I am back to the other issue with the texlive docker image from the first two commits: the Fira font doesn't work with XeLaTex.

My Latex foo isn't strong enough for this.

So, here a draft PR to see whether someone else might know what's needed to make this work.

And a final note: while the use of plain Ubuntu is slow, it documents which packages are actually needed.