### PR TITLE
Fix Typos

### DIFF
--- a/example-programming.tex
+++ b/example-programming.tex
@@ -231,7 +231,7 @@ I want to thank ....
   At that point, you can load necessary {LaTeX} packages. We already load some
   important packages with the \lstinline|programming| class and that there are
   certain packages that are not recommended or incompatible with this class.
-  Refer to \autoref{sec:pack-cons} for which packages are recommended. The you
+  Refer to \autoref{sec:pack-cons} for which packages are recommended. Then you
   start the document with \lstinline|\begin{document}|.
 
   You have to provide details to your submission that will be used during the
@@ -903,7 +903,7 @@ culpa qui officia deserunt mollit anim id est laborum.
   similar are \emph{below} the content, flush left.
 \item %
   \begin{minipage}[t]{.4\linewidth}
-    Tables adhere to best practice layout~\cite{booktabs}. The do not contain
+    Tables adhere to best practice layout~\cite{booktabs}. They do not contain
   vertical lines and only few horizontal lines.
   \end{minipage}
   {\renewcommand{\arraystretch}{.6}


### PR DESCRIPTION
Other typos are still present in the Overleaf template, which have been fixed in this repo. Maybe the Overleaf template needs an update?